### PR TITLE
fix (practically) endless recursion in SVG interpolation

### DIFF
--- a/backend/filereaders/svg_path_reader.py
+++ b/backend/filereaders/svg_path_reader.py
@@ -332,8 +332,14 @@ class SVGPathReader:
         d2 = abs(((x2 - x4) * dy - (y2 - y4) * dx))
         d3 = abs(((x3 - x4) * dy - (y3 - y4) * dx))
 
-        if (d2+d3)**2 < 5.0 * self._tolerance2 * (dx*dx + dy*dy):
+        # Stop recursion if current changes are already less then the tolerance
+        abort = False
+        if dx*dx < self._tolerance2 and dy*dy < self._tolerance2 and d2*d2 < self._tolerance2 and d3*d3 < self._tolerance2:
+            abort = True
+        elif (d2+d3)**2 < 5.0 * self._tolerance2 * (dx*dx + dy*dy):
             # added factor of 5.0 to match circle resolution
+            abort = True
+        if abort:
             subpath.append([x1234, y1234])
             return
 
@@ -361,8 +367,14 @@ class SVGPathReader:
         dy = y3-y1
         d = abs(((x2 - x3) * dy - (y2 - y3) * dx))
 
-        if d*d <= 5.0 * self._tolerance2 * (dx*dx + dy*dy):
+        # Stop recursion if current changes are already less then the tolerance
+        abort = False
+        if dx*dx < self._tolerance2 and dy*dy < self._tolerance2 and d*d < self._tolerance2:
+            abort = True
+        elif d*d <= 5.0 * self._tolerance2 * (dx*dx + dy*dy):
             # added factor of 5.0 to match circle resolution
+            abort = True
+        if abort:
             subpath.append([x123, y123])
             return
 

--- a/backend/filereaders/svg_tag_reader.py
+++ b/backend/filereaders/svg_tag_reader.py
@@ -49,7 +49,7 @@ class SVGTagReader:
         node.
 
         Any path data is ultimately handled by
-        self._pathReader.add_path(...). For any  geometry that is not
+        self._pathReader.add_path(...). For any geometry that is not
         already in the 'd' attribute of a 'path' tag this class
         converts it first to this format and then delegates it to
         add_path(...).
@@ -224,7 +224,7 @@ class SVGTagReader:
         # =pass5:4000mm/min:100%=
         # =pass6:4000:100=
         text_accum = [tag.text or '']
-        # # search one level deep
+        # search one level deep
         for child in tag:
             text_accum.append(child.text or '')
         text_accum = ' '.join(text_accum)


### PR DESCRIPTION
basically, stop recurrence/subdivision of paths, when the current path size is smaller then the tolerance in all dimensions.
it seems to work well, according to a first visual inspection of the interpolated result, and is definitely fast.